### PR TITLE
Convert the backend meta generation for episodics to scale much nicer

### DIFF
--- a/pkg/data/loaders.go
+++ b/pkg/data/loaders.go
@@ -62,6 +62,20 @@ func loadEpisodic(stmt *sqlite.Stmt) (*types.Episodic, error) {
 	return ep, nil
 }
 
+func loadEpisodicMeta(stmt *sqlite.Stmt) *types.EpisodicMeta {
+	dn, _ := time.Parse(time.RFC3339, stmt.GetText("next_episode_date"))
+
+	return &types.EpisodicMeta{
+		HasSpecials:          stmt.GetBool("has_specials"),
+		NextEpisodeDate:      dn,
+		Seasons:              stmt.GetText("seasons"),
+		TotalEpisodeFiles:    int(stmt.GetInt64("total_episode_files")),
+		TotalEpisodes:        int(stmt.GetInt64("total_episode_count")),
+		TotalEpisodesWatched: int(stmt.GetInt64("total_episodes_watched")),
+		TotalSpecialsCount:   int(stmt.GetInt64("total_specials_count")),
+	}
+}
+
 func loadFilesystem(stmt *sqlite.Stmt) (types.Filesystem, error) {
 	lc, _ := time.Parse(time.RFC3339, stmt.GetText("last_checked"))
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,6 +97,10 @@ func (s *Server) logger(l *zap.SugaredLogger) gin.HandlerFunc {
 	}
 }
 
+func bad(e error) (interface{}, []string, int) {
+	return gin.H{}, []string{e.Error()}, http.StatusInternalServerError
+}
+
 func good(d interface{}) (interface{}, []string, int) {
 	return d, []string{}, http.StatusOK
 }

--- a/pkg/types/collections.go
+++ b/pkg/types/collections.go
@@ -30,7 +30,18 @@ type Episodic struct {
 	Genre      string `json:"genre" db:"genre"`
 	PublicDBID string `json:"public_db_id" db:"public_db_id"`
 
-	Episodes []*Episode `json:"episodes" db:"-"`
+	Episodes []*Episode    `json:"episodes" db:"-"`
+	Meta     *EpisodicMeta `json:"meta"`
+}
+
+type EpisodicMeta struct {
+	HasSpecials          bool      `json:"has_specials"`           // has_specials
+	NextEpisodeDate      time.Time `json:"next_episode_date"`      // next_episode_date
+	Seasons              string    `json:"seasons"`                // seasons
+	TotalEpisodeFiles    int       `json:"total_episode_files"`    // total_episode_files
+	TotalEpisodes        int       `json:"total_episodes"`         // total_episode_count
+	TotalEpisodesWatched int       `json:"total_episodes_watched"` // total_episodes_watched
+	TotalSpecialsCount   int       `json:"total_specials_count"`   // total_specials_count
 }
 
 type Episode struct {

--- a/src/components/EpisodicEdit.vue
+++ b/src/components/EpisodicEdit.vue
@@ -117,12 +117,12 @@ export default {
         this.$store.dispatch('getIntegrations').then(() => {
           this.integrations = this.$store.getters.allIntegrations;
           this.$store.dispatch('getEpisodic', {id: this.id}).then(() => {
-            this.title = this.episodic[this.id].episodic.title;
-            this.year = this.episodic[this.id].episodic.year;
-            this.integration = this.episodic[this.id].episodic.integration_id;
-            this.filesystem = this.episodic[this.id].episodic.filesystem_id;
-            this.path = this.episodic[this.id].episodic.path;
-            this.integration_id = this.episodic[this.id].episodic.public_db_id;
+            this.title = this.episodic[this.id].title;
+            this.year = this.episodic[this.id].year;
+            this.integration = this.episodic[this.id].integration_id;
+            this.filesystem = this.episodic[this.id].filesystem_id;
+            this.path = this.episodic[this.id].path;
+            this.integration_id = this.episodic[this.id].public_db_id;
           });
         });
       });

--- a/src/components/PageEpisodics.vue
+++ b/src/components/PageEpisodics.vue
@@ -13,22 +13,22 @@
             :items="items"
             density="comfortable"
             multi-sort
-            :sort-by="[{ key: 'meta.have_episode_files', order: 'asc' }]">
+            :sort-by="[{ key: 'meta.total_episode_files', order: 'asc' }]">
 
             <template v-slot:item.title="{ item }">
               <v-btn variant="text" density="comfortable" class="text-none" :to="'/episodic/' + item.id">
                 {{ item.title }} ({{ item.year }})
               </v-btn>
             </template>
-            <template v-slot:item.meta.have_episode_files="{ item }">
+            <template v-slot:item.meta.total_episode_files="{ item }">
               <EpisodeGradiantChip
-                :text="'Files: '+item.meta.have_episode_files+' / '+item.meta.total_episodes"
-                :gradient="Math.floor((item.meta.have_episode_files/item.meta.total_episodes) * 10)" />
+                :text="'Files: '+item.meta.total_episode_files+' / '+item.meta.total_episodes"
+                :gradient="Math.floor((item.meta.total_episode_files/item.meta.total_episodes) * 10)" />
             </template>
-            <template v-slot:item.meta.watched_episodes="{ item }">
+            <template v-slot:item.meta.total_episodes_watched="{ item }">
               <EpisodeGradiantChip
-                :text="'Watched: '+item.meta.watched_episodes+' / '+item.meta.total_episodes"
-                :gradient="Math.floor((item.meta.watched_episodes/item.meta.total_episodes) * 10)" />
+                :text="'Watched: '+item.meta.total_episodes_watched+' / '+item.meta.total_episodes"
+                :gradient="Math.floor((item.meta.total_episodes_watched/item.meta.total_episodes) * 10)" />
             </template>
             <template v-slot:item.status="{ item }">
               <v-chip density="comfortable" :text="item.is_active ? 'Active' : 'Ended'" :color="item.is_active ? 'green' : 'red'" variant="outlined" />
@@ -54,8 +54,8 @@ export default {
   data: () => ({
     headers: [
       {title: 'Title', align: 'left', key: 'title'},
-      {title: 'Files', align: 'center', key: 'meta.have_episode_files' },
-      {title: 'Watched', align: 'center', key: 'meta.watched_episodes' },
+      {title: 'Files', align: 'center', key: 'meta.total_episode_files' },
+      {title: 'Watched', align: 'center', key: 'meta.total_episodes_watched' },
       {title: 'Status', align: 'center', key: 'status', sortable: false},
       {title: 'Next Ep', align: 'center', key: 'available', sortable: false},
     ],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,16 +14,10 @@ export default createStore({
       delete state.episodic[id];
     },
     resetEpisodic(state, ep) {
-      state.episodic[ep.data.episodic.id] = ep.data;
+      state.episodic[ep.id] = ep;
     },
     resetEpisodics(state, eps) {
-      let episodics = eps.data.episodics;
-      let meta = eps.data.meta;
-
-      episodics.forEach((v) => {
-        v.meta = meta[v.id];
-      });
-      state.episodics = episodics;
+      state.episodics = eps;
     },
     resetFilesystems(state, fs) {
       state.filesystems = fs.data;
@@ -42,6 +36,10 @@ export default createStore({
     },
     allIntegrations: state => {
       return state.integrations;
+    },
+
+    episodicById: (state) => (id) => {
+      return state.episodic[id];
     },
   },
 
@@ -78,7 +76,7 @@ export default createStore({
       return new Promise((resolve) => {
         apiClient.getEpisodic(id).then((data) => {
           if (data.errors.length < 1 && data.meta.errors < 1) {
-            commit('resetEpisodic', data);
+            commit('resetEpisodic', data.data);
           }
           resolve();
         });
@@ -89,7 +87,7 @@ export default createStore({
       return new Promise((resolve) => {
         apiClient.getEpisodics().then((data) => {
           if (data.errors.length < 1 && data.meta.errors < 1) {
-            commit('resetEpisodics', data);
+            commit('resetEpisodics', data.data);
           }
           resolve();
         });


### PR DESCRIPTION
# Checklist

- [x] Tagged appropriate reviewers.
- [x] Ran all appropriate tests.
- [x] Included details and screenshots in PR description.
- [x] Added references for any issues being actioned.

## Description

Moving the `episodic.meta` generation into SQL, rather than loading **all** episodes for `1..x` Episodic entries. This way, at least _somewhat_ efficient querying is performed to generate the metadata rather than computing in Go, which itself was fast, more that there was a **lot** of data being put into memory for very little numbers.

## Tests

Soon ™️.
